### PR TITLE
ACMW-0036: Changed name events-main-background

### DIFF
--- a/src/components/events/Events.js
+++ b/src/components/events/Events.js
@@ -30,8 +30,8 @@ class Events extends React.Component {
                         <p>Never miss an <span className="emphasis">Event</span></p>
                         <p>Stay in the loop</p>
                     </div>
-                    {/* events-main-background doesn't work, so <Image> is used to replace it */}
-                    <Image style={{ height: '50rem', width: '95rem' }} src={require('./images/acm_events_background.jpg')} fluid />
+                    {/* The class name "events-main-background" doesn't work. Changing the class name makes the code work */}
+                    <div className="background-image"></div>
                 </div>
                 <div className="blue-line"></div>
                 <Container className="current-events-container"> 

--- a/src/components/events/events.css
+++ b/src/components/events/events.css
@@ -41,10 +41,10 @@
     margin-bottom: 4rem;
 }
 
-/* When CSS is changed, the background image doesn't change at all. Broken code or bug? 
-   I replaced the background image with an <Image>*/
-.events-main-background {
-    height: 100vh;
+/* When the class name is "events-main-background" and the CSS properties are changed, the background image size doesn't change at all. 
+   Maybe a bug? However, after changing the class name, the changes will show. */
+.background-image {
+    height: 110vh;
     background: url("images/acm_events_background.jpg") no-repeat center !important;
     background-size: cover !important;
     align-self: center;


### PR DESCRIPTION
When the class name is "events-main-background" and the CSS properties are changed, the background image size doesn't change at all. Maybe a bug? However, after changing the class name, the changes will show.

This fixes the image/text from blocking (covering) the calendar.