### PR TITLE
ACMW-0063: Fixed buttons and centered calendar

### DIFF
--- a/src/components/calendar/Calendar.css
+++ b/src/components/calendar/Calendar.css
@@ -72,6 +72,7 @@
 .calendar-header {
     display: flex;
     font-weight: 500;
+    padding-bottom: 10px;
 }
 
 .calendar-header button {
@@ -125,5 +126,10 @@
 
     .test2 {
         display: inline;
+    }
+
+    .month-header {
+        font-size: 1.25rem;
+        font-weight: 400;
     }
 }

--- a/src/components/events/Events.js
+++ b/src/components/events/Events.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import './events.css';
-import { Card, Button, Jumbotron, Container} from 'react-bootstrap';
+import { Card, Button, Jumbotron, Container } from 'react-bootstrap';
 import Calendar from "../calendar/Calendar.js";
 
 // This component won't hold a state for not but decided 
@@ -98,8 +98,8 @@ class Events extends React.Component {
                 <Calendar /> */}
 
                 <div>
-                    {/* Something wrong events-main-text */}
-                    <div className="events-main-text">
+                    {/* The class name "events-main-text" doesn't work. Changing the class name makes the code work */}
+                    <div className="events-text">
                         <p>Never miss an <span className="emphasis">Event</span></p>
                     </div>
                     {/* The class name "events-main-background" doesn't work. Changing the class name makes the code work */}
@@ -109,15 +109,10 @@ class Events extends React.Component {
 
                 {important_upcoming_events}
 
-                <Container className="current-events-container">
-                    {/* Calendar is floats left*/}
-                    {/*<div className="events-calendar-center">
-                         <Calendar/>
-                    </div>*/}
-                    <div className="row justify-content-center">
-                        <div className="events-calendar-center">
-                            <Calendar />
-                        </div>
+                {/* Using fluid="sm" keeps calendar centered */}
+                <Container fluid="sm">
+                    <div className="events-calendar-center">
+                        <Calendar />
                     </div>
                 </Container>
             </div>

--- a/src/components/events/events.css
+++ b/src/components/events/events.css
@@ -13,29 +13,31 @@
 }
 
 /* Text is blocking (covering) the calendar. Bug? */
-/* There is something wrong with the events-main-text class */
-.events-main-text {
-    height: 100%;
+/* The class name "events-main-text" doesn't work. Changing the class name makes the code work */
+.events-text {
+    /* When height: 100%, the calendar buttons do not work. Changing it to use "vh" works.*/
+    /* Background-image height and events-text height affect each other when one of them changed */
+    height: 75vh;
     width: 100%;
     position: absolute;
     z-index: 2;
-    font-size: 4.4rem;
+    font-size: 4.0rem;
     color: white;
     font-weight: bold;
-    line-height: 1.2;
+    line-height: 1;
 
     display: grid;
     grid-template-rows: 1fr 1.4fr;
     padding-left: 3rem;
 }
-
-.events-main-text p:first-of-type {
+/* The class name "events-main-text" doesn't work. Changing the class name makes the code work */
+.events-text p:first-of-type {
     grid-column: 1/2;
     grid-row:1/2;
     align-self: end;
 }
-
-.events-main-text p:nth-of-type(2) {
+/* The class name "events-main-text" doesn't work. Changing the class name makes the code work */
+.events-text p:nth-of-type(2) {
     grid-row:2/3;
     grid-column: 1/2;
     align-self: start;
@@ -45,6 +47,7 @@
 /* When the class name is "events-main-background" and the CSS properties are changed, the background image size doesn't change at all. 
    Maybe a bug? However, after changing the class name, the changes will show. */
 .background-image {
+    /* Background-image height and events-text height affect each other when one of them is changed */
     height: 70vh;
     background: url("images/acm_events_background.jpg") no-repeat center !important;
     background-size: cover !important;
@@ -73,15 +76,15 @@
     .jumbo-text{
         font-size: 2.1rem;
     }
-
-    .events-main-text {
-        padding-left: 1rem;
+    /* The class name "events-main-text" doesn't work. Changing the class name makes the code work */
+    .events-text {
+        padding-top: 30vh;
+        padding-left: 0.5rem;
         font-size: 3.4rem;
     }
 }
 
 @media only screen and (max-width: 420px){
-
     .current-events-header {
         width: 100%;
         font-size: 3.3rem;


### PR DESCRIPTION
The class name "events-main-text" doesn't work. Changing the class name makes the code work.  When height: 100%, the calendar buttons do not work. Changing it to use "vh" works. 

Background-image height and events-text height affect each other when one of them changed.